### PR TITLE
PR that fixes https://github.com/Bioconductor/AnnotationHubData/issues/1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: AnnotationHubData
 Type: Package
 Title: Transform public data resources into Bioconductor Data Structures
-Version: 1.15.7
+Version: 1.15.8
 Encoding: UTF-8
 Authors@R: c(
 	person("Martin", "Morgan", role="ctb"),

--- a/R/makeGencodeGFF.R
+++ b/R/makeGencodeGFF.R
@@ -138,10 +138,13 @@
     taxid <- ifelse(species=="Human", 9606L, 1090L)
     genome <- .gencodeGenome(species, release)
     genome <- rep(genome, length(fileurls))
+    genome[grepl('_mapping/', rdatapath)] <- gsub('.*/', '',
+        gsub('_mapping/.*', '',
+            rdatapath[grepl('_mapping/', rdatapath)]
+        )
+    )
     scSpecies <- rep(scSpecies, length(fileurls))
     taxid <- rep(taxid, length(fileurls))
-    genome <- .gencodeGenome(species, release)
-    genome <- rep(genome, length(fileurls))
 
     cbind(df, rdatapath, description, tags, species=scSpecies, taxid, genome,
          stringsAsFactors=FALSE)
@@ -149,12 +152,14 @@
 
 
 ## STEP 1: make function to process metadata into AHMs
-makeGencodeGFFsToAHMs <- function(currentMetadata, justRunUnitTest, BiocVersion){
+makeGencodeGFFsToAHMs <- function(justRunUnitTest = FALSE,
+    BiocVersion = BiocManager::version(), species = 'Human', release = '23',
+    filetype = 'gff'){
 
     ## important - here you need to know which species and release you want to
     ## add files for.
-    rsrc <- .gencodeSourceUrls(species="Human", release="23", filetype="gff",
-         justRunUnitTest)
+    rsrc <- .gencodeSourceUrls(species = species, release = release,
+        filetype = filetype, justRunUnitTest = justRunUnitTest)
 
     description <- rsrc$description
     title <- basename(rsrc$fileurl)


### PR DESCRIPTION
Hi,

This PR fixes https://github.com/Bioconductor/AnnotationHubData/issues/1 by enabling other Gencode releases beyond v23 and detecting when the data was lifted over from hg38 to hg19.

The longer context is provided at https://github.com/Bioconductor/Contributions/issues/1191#issuecomment-537605713. With this PR, you can run the following commands to see the changes in effect:

```R
devtools::load_all()
.gencodeSourceUrls(species = 'Human', release = '31', filetype = 'gff', justRunUnitTest = FALSE)
makeGencodeGFFsToAHMs(release = '31')
```

You could then use something like this to make the AnnotationHub packages for the multiple Gencode versions for human.

```R
makeGencodeGFFsToAHMs_multiple_human <- function() {
    ## Here just two for testing:
    releases <- c('23', '31')
    ## For all including v23
    # releases <- as.character(23:31)
    hubs <- lapply(releases, function(rel) makeGencodeGFFsToAHMs(release = rel))
    unlist(hubs)
}
makeAnnotationHubResource("GencodeGffImportPreparer",
                          makeGencodeGFFsToAHMs_multiple_human)
```

Or multiple calls like:

```R
makeAnnotationHubResource("GencodeGffImportPreparer",
                          makeGencodeGFFsToAHMs(release = '23'))
makeAnnotationHubResource("GencodeGffImportPreparer",
                          makeGencodeGFFsToAHMs(release = '31'))
```

Best,
Leo

PS: `.gencodeSourceUrls` had duplicated code for defining the `genome` object.

PS2: It'd be nice to have a link to https://github.com/Bioconductor/AnnotationHubData in the `DESCRIPTION` to make this repo easier to find ^^. Though that's not part of this PR.