### PR TITLE
Filter metadata

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -103,7 +103,7 @@ export(
     metadata, "metadata<-",
     metadataList, metadataTable,
     annotationHubRoot,
-    sourceUrls
+    sourceUrls, getPackageMetadata
 )
 
 exportMethods(
@@ -113,7 +113,7 @@ exportMethods(
     metadata, "metadata<-",
     metadataList, metadataTable,
     annotationHubRoot,
-    sourceUrls
+    sourceUrls, getPackageMetadata
 )
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/R/AnnotationHubMetadata-class.R
+++ b/R/AnnotationHubMetadata-class.R
@@ -315,6 +315,16 @@ makeAnnotationHubMetadata <- function(pathToPackage, fileName=character())
     meta <- .readMetadataFromCsv(pathToPackage, fileName)
     .package <- unname(description[,"Package"])
 
+    ah <- AnnotationHub::AnnotationHub()
+    inhub <- getPackageMetadata(ah, .package)
+
+    res <- paste0(meta$Location_Prefix, meta$RDataPath) %in% paste0(inhub$Location_Prefix, inhub$RDataPath)
+    if (all(res))  stop("no new data to add")
+
+    if (any(!res)) {
+        meta = meta[(!res),]
+    }
+
     ## check for Tags in metadata
     ## filter out packageName as already tracked in database with preparerclass
     if (length(meta$Tags)){

--- a/R/AnnotationHubMetadata-class.R
+++ b/R/AnnotationHubMetadata-class.R
@@ -300,79 +300,73 @@ globalVariables(c("BiocVersion", "Coordinate_1_based", "DataProvider",
 ## Used for contributed packages, not internal recipes.
 makeAnnotationHubMetadata <- function(pathToPackage, fileName=character())
 {
-    path <- file.path(pathToPackage, "inst", "extdata")
-    if (!length(fileName))
-        fileName <- list.files(path, pattern="*\\.csv")
-    ans <- lapply(fileName,
-        function(xx) {
+    stopifnot(length(fileName) <= 1)
 
-            description <- read.dcf(file.path(pathToPackage, "DESCRIPTION"))
-            .views <- strsplit(gsub("\\s", "", description[,"biocViews"]), ",")[[1]]
-            if (length(.views) <= 1) stop("Add 2 or more biocViews to your DESCRIPTION. Required: AnnotationHub or AnnotationHubSoftware")
-            .checkValidViews(.views)
-            ## filter views for common/not useful terms
-            .views = setdiff(.views,
-                             c("AnnotationData", "AnnotationHub","ChipManufacture", "ChipName", "Organism", "PackageType",
-                               "Software", "AssayDomain", "BiologicalQuestion","ResearchField", "Technology", "WorkflowStep")
-                             )
+    description <- read.dcf(file.path(pathToPackage, "DESCRIPTION"))
+    .views <- strsplit(gsub("\\s", "", description[,"biocViews"]), ",")[[1]]
+    if (length(.views) <= 1) stop("Add 2 or more biocViews to your DESCRIPTION. Required: AnnotationHub or AnnotationHubSoftware")
+    .checkValidViews(.views)
+    ## filter views for common/not useful terms
+    .views = setdiff(.views,
+                     c("AnnotationData", "AnnotationHub","ChipManufacture", "ChipName", "Organism", "PackageType",
+                       "Software", "AssayDomain", "BiologicalQuestion","ResearchField", "Technology", "WorkflowStep")
+                     )
 
-            meta <- .readMetadataFromCsv(pathToPackage, xx)
-            .package <- unname(description[,"Package"])
+    meta <- .readMetadataFromCsv(pathToPackage, fileName)
+    .package <- unname(description[,"Package"])
 
-            ## check for Tags in metadata
-            ## filter out packageName as already tracked in database with preparerclass
-            if (length(meta$Tags)){
-                .tags <- strsplit(meta$Tags, ":")
-                .tags <- lapply(.tags,
-                                FUN<- function(x, views, packageName){
-                                    setdiff(sort(unique(c(x, views))), packageName)},
-                                views = .views, packageName=.package)
-                if (any(unlist(lapply(.tags, FUN=length)) < 2))
-                    stop("Add 2 or more Tags to each resource by either\n",
+    ## check for Tags in metadata
+    ## filter out packageName as already tracked in database with preparerclass
+    if (length(meta$Tags)){
+        .tags <- strsplit(meta$Tags, ":")
+        .tags <- lapply(.tags,
+                        FUN<- function(x, views, packageName){
+                            setdiff(sort(unique(c(x, views))), packageName)},
+                        views = .views, packageName=.package)
+        if (any(unlist(lapply(.tags, FUN=length)) < 2))
+            stop("Add 2 or more Tags to each resource by either\n",
+                 "  adding 'Tags' column to metadata or\n",
+                 "  adding additional meaningful biocViews terms in DESCRIPTION")
+    }else{
+        if (length(.views)){
+            .tags = vector("list", nrow(meta))
+            .tags <- lapply(.tags,
+                            FUN<- function(x, views, packageName){
+                                setdiff(sort(unique(views)), packageName)},
+                            views = .views, packageName=.package)
+            if (any(unlist(lapply(.tags, FUN=length)) < 2))
+                stop("Add 2 or more Tags to each resource by either\n",
+                     "  adding 'Tags' column to metadata or\n",
+                     "  adding additional meaningful biocViews terms in DESCRIPTION")
+        }else{
+            stop("Add 2 or more Tags to each resource by either\n",
                          "  adding 'Tags' column to metadata or\n",
-                         "  adding additional meaningful biocViews terms in DESCRIPTION")
-            }else{
-                if (length(.views)){
-                    .tags = vector("list", nrow(meta))
-                    .tags <- lapply(.tags,
-                                    FUN<- function(x, views, packageName){
-                                        setdiff(sort(unique(views)), packageName)},
-                                    views = .views, packageName=.package)
-                    if (any(unlist(lapply(.tags, FUN=length)) < 2))
-                        stop("Add 2 or more Tags to each resource by either\n",
-                             "  adding 'Tags' column to metadata or\n",
-                             "  adding additional meaningful biocViews terms in DESCRIPTION")
-                }else{
-                     stop("Add 2 or more Tags to each resource by either\n",
-                         "  adding 'Tags' column to metadata or\n",
-                         "  adding additional meaningful biocViews terms in DESCRIPTION")
-                }
-            }
+                 "  adding additional meaningful biocViews terms in DESCRIPTION")
+        }
+    }
 
-            .RDataPaths <- meta$RDataPath
+    .RDataPaths <- meta$RDataPath
 
-            lapply(seq_len(nrow(meta)), function(x) {
-                with(meta[x, ], AnnotationHubMetadata(
-                    Title=Title, Description=Description,
-                    BiocVersion=BiocVersion, Genome=Genome,
-                    SourceType=SourceType,
-                    SourceUrl=SourceUrl,
-                    SourceVersion=SourceVersion,
-                    Species=Species, TaxonomyId=TaxonomyId,
-                    Coordinate_1_based=Coordinate_1_based,
-                    DataProvider=DataProvider,
-                    Maintainer=Maintainer,
-                    RDataClass=RDataClass, Tags=.tags[[x]],
-                    RDataDateAdded=RDataDateAdded,
-                    RDataPath=.RDataPaths[[x]],
-                    Recipe=NA_character_,
-                    DispatchClass=DispatchClass,
-                    PreparerClass=.package,
-                    Location_Prefix=Location_Prefix))
-            })
-    })
-    names(ans) <- fileName
-    ans
+    lapply(seq_len(nrow(meta)), function(x) {
+        with(meta[x, ], AnnotationHubMetadata(
+                            Title=Title, Description=Description,
+                            BiocVersion=BiocVersion, Genome=Genome,
+                            SourceType=SourceType,
+                            SourceUrl=SourceUrl,
+                            SourceVersion=SourceVersion,
+                            Species=Species, TaxonomyId=TaxonomyId,
+                            Coordinate_1_based=Coordinate_1_based,
+                            DataProvider=DataProvider,
+                            Maintainer=Maintainer,
+                            RDataClass=RDataClass, Tags=.tags[[x]],
+                            RDataDateAdded=RDataDateAdded,
+                            RDataPath=.RDataPaths[[x]],
+                            Recipe=NA_character_,
+                            DispatchClass=DispatchClass,
+                            PreparerClass=.package,
+                            Location_Prefix=Location_Prefix))
+    }
+    )
 }
 
 AnnotationHubMetadata <-

--- a/R/HubMetadata-class.R
+++ b/R/HubMetadata-class.R
@@ -97,6 +97,10 @@ setGeneric("hubError<-", signature=c("x", "value"),
     function(x, value) standardGeneric("hubError<-")
 )
 
+setGeneric("getPackageMetadata", signature="packageName",
+    function(hub, packageName, fileName) standardGeneric("getPackageMetadata")
+)
+
 ## ------------------------------------------------------------------------------
 ## getters and setters
 ##
@@ -180,4 +184,16 @@ setMethod(show, "HubMetadata",
         txt <- paste0(slt, ": ", paste0(as.character(value), collapse=" "))
         cat(strwrap(txt), sep="\n  ")
     }
+})
+
+
+setMethod("getPackageMetadata", "character",
+          function(hub, packageName, fileName)
+{
+    stopifnot(!missing(packageName), length(packageName)==1)
+    mat = .getmetadata(hub, packageName)
+    if(!missing(fileName)){
+        write.csv(mat, file=fileName, row.names=FALSE)
+    }
+    mat
 })

--- a/R/utils.R
+++ b/R/utils.R
@@ -240,3 +240,46 @@ print.pointer <- function(x, ...)
 # ..(z)$fish <- "trout"
 # ..(z)
 # x
+
+
+
+
+
+.getmetadata <- function(path, pkgname)
+{
+    if (is(path, "Hub")){
+        db_path <- AnnotationHub::dbfile(path)
+    } else if (class(path) == "character"){
+        db_path <- path
+    }else{
+        db_path <- RSQLite::dbGetInfo(path)$dbname
+    }
+    query <- paste0(
+        "SELECT DISTINCT resources.ah_id, resources.title, resources.description, biocversions.biocversion, resources.species, resources.genome, resources.taxonomyid, input_sources.sourcetype, input_sources.sourceurl, input_sources.sourceversion, resources.coordinate_1_based, resources.dataprovider, resources.maintainer, rdatapaths.rdataclass, rdatapaths.dispatchclass, location_prefixes.location_prefix, rdatapaths.rdatapath, tags.tag FROM resources, rdatapaths, biocversions, input_sources, location_prefixes, tags WHERE resources.id == rdatapaths.resource_id AND resources.location_prefix_id == location_prefixes.id AND biocversions.resource_id == resources.id AND input_sources.resource_id == resources.id AND tags.resource_id == resources.id AND resources.preparerclass == '",pkgname,"'")
+    if (is(path, "Hub")){
+        conn <- AnnotationHub::dbfile(path)
+    } else if (class(path) == "character"){
+        conn <- AnnotationHub:::.db_open(path)
+        on.exit(AnnotationHub:::.db_close(conn))
+    }else{
+        conn <- path
+    }
+    mat <- AnnotationHub:::.db_query(conn, query)
+
+    ## now fix tags -- tags format is ":" seperated but in database each unique
+    ## column results in multiple rows
+    for(vl in unique(mat[,"ah_id"])){
+        dx = which(mat[,"ah_id"]==vl)
+        mat[dx,"tag"] = paste0(mat[dx,"tag"], collapse=":")
+    }
+    mat = unique(mat)
+    ## add hubid column for base resource
+    mat = cbind(hubid = gsub('\\..*', '',mat$ah_id), mat)
+    ## fix colnames to be correct case for valid metadata
+    colnames(mat) = c("HubId", "ah_id", "Title", "Description", "BiocVersion",
+                      "Species", "Genome", "TaxonomyId", "SourceType", "SourceUrl",
+                      "SourceVersion", "Coordinate_1_based", "DataProvider",
+                      "Maintainer", "RDataClass", "DispatchClass",
+                      "Location_Prefix", "RDataPath", "Tags")
+    mat
+}


### PR DESCRIPTION
1. helper function for developers to get a complete valid metadata file based on what is already in the hubs
2. remove lapply over all csv files in inst/extdata.  annoying and dangerous processing. removed in experimenthub already
3. when running the validation function on the metadata (makeAnnotationhubMetadata) it will check against the already in the hub resources for which are new for maintainers using a single metadata file.  